### PR TITLE
bugfix: remove MQTT client ID from base topic

### DIFF
--- a/homie.c
+++ b/homie.c
@@ -352,16 +352,12 @@ fail:
 esp_err_t homie_mktopic(char *topic, const char *subtopic, const size_t topic_size)
 {
     int ret;
-    if (!config->mqtt_config.client_id) {
-        ESP_LOGE(TAG, "client_id in mqtt_config must be set");
-        goto fail;
-    }
     if (!config->base_topic) {
-        ESP_LOGE(TAG, "base_topic in mqtt_config must be set");
+        ESP_LOGE(TAG, "base_topic must be set in homie_config");
         goto fail;
     }
-    ret = snprintf(topic, topic_size, "%s/%s/%s",
-            config->base_topic, config->mqtt_config.client_id, subtopic);
+    ret = snprintf(topic, topic_size, "%s/%s",
+            config->base_topic, subtopic);
 
     if (ret < 0 || ret >= topic_size) {
         ESP_LOGE(TAG, "homie_mktopic(): topic is too short: ret: %d, topic_size: %d",

--- a/include/homie.h
+++ b/include/homie.h
@@ -56,7 +56,7 @@ typedef struct
 {
     esp_mqtt_client_config_t mqtt_config;                   //!< MQTT configuration
     char device_name[HOMIE_MAX_DEVICE_NAME_LEN];            //!< Descriptive device name
-    char base_topic[HOMIE_MAX_MQTT_BASE_TOPIC_LEN];         //!< Root topic, usually `homie`.
+    char base_topic[HOMIE_MAX_MQTT_BASE_TOPIC_LEN];         //!< Device base topic, usually `homie/unique_id`.
     char firmware_name[HOMIE_MAX_FIRMWARE_NAME_LEN];        //!< Firmware name
     char firmware_version[HOMIE_MAX_FIRMWARE_VERSION_LEN];  //!< Firmware version
     bool ota_enabled;                                       //!< Enable or disable OTA


### PR DESCRIPTION
so that users can use arbitrary string for the base topic, like
`homie/$MAC_ADDRESS` or `foo/bar/buz/$MAC_ADDRESS`